### PR TITLE
Add cbor content format

### DIFF
--- a/txthings/coap.py
+++ b/txthings/coap.py
@@ -254,7 +254,8 @@ media_types = {0: 'text/plain',
                41: 'application/xml',
                42: 'application/octet-stream',
                47: 'application/exi',
-               50: 'application/json'}
+               50: 'application/json',
+               60: 'application/cbor'}
 """A map from CoAP-assigned integral codes to Internet media type descriptions."""
 
 media_types_rev = {v:k for k, v in media_types.items()}


### PR DESCRIPTION
I'm not sure whether you are interested in patches to txThings, but if so, here's a simple one that adds the CBOR Content-Format ID.  CBOR tends to be useful in the same environments where CoAP is useful, and provides data encoding similar to JSON.

CBOR, as well as its CoAP content format are documented in RFC7049
(http://tools.ietf.org/html/rfc7049 Section 7.4).  Add the encoding id so that
applications can use the definitions provided by txthings.