### PR TITLE
Add LICENSE file and call out license in package.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) Copyright (c) 2012 Maciej Wasilak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 setup(name='txThings',
       version='0.2.0',
       description='CoAP protocol implementation for Twisted Framework',
+      license="MIT",
       author='Maciej Wasilak',
       author_email='wasilak@gmail.com',
       url='https://github.com/siskin/txThings/',


### PR DESCRIPTION
The homepage specifies the license, however, for systems that do
validation on an actual license file (e.g. Yocot, or something that calls it out),
it's nice to have the file included.  Additionally, it's nice when the
license is called out in PyPI, which should be the case with the
setup.py changes.