### PR TITLE
Python 3 compatibility

### DIFF
--- a/examples/server.py
+++ b/examples/server.py
@@ -59,7 +59,7 @@ class BlockResource (resource.CoAPResource):
         return defer.succeed(response)
 
     def render_PUT(self, request):
-        print 'PUT payload: ' + request.payload
+        log.msg('PUT payload: %s', request.payload)
         payload = "Mr. and Mrs. Dursley of number four, Privet Drive, were proud to say that they were perfectly normal, thank you very much."
         response = coap.Message(code=coap.CHANGED, payload=payload)
         return defer.succeed(response)
@@ -139,7 +139,7 @@ class CoreResource(resource.CoAPResource):
         data = []
         self.root.generateResourceList(data, "")
         payload = ",".join(data)
-        print payload
+        log.msg("%s", payload)
         response = coap.Message(code=coap.CONTENT, payload=payload)
         response.opt.content_format = coap.media_types_rev['application/link-format']
         return defer.succeed(response)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,13 @@
 
 from setuptools import setup, find_packages
 
+import sys
+
+if sys.version_info.major >= 3:
+    py2_ipa = []
+else:
+    py2_ipa = [ 'py2-ipaddress>=3.4.1' ]
+
 setup(name='txThings',
       version='0.2.0',
       description='CoAP protocol implementation for Twisted Framework',
@@ -9,5 +16,5 @@ setup(name='txThings',
       author_email='wasilak@gmail.com',
       url='https://github.com/siskin/txThings/',
       packages=find_packages(exclude=["*.test", "*.test.*"]),
-      install_requires = ['twisted>=14.0.0', 'py2-ipaddress>=3.4.1'],
+      install_requires = ['twisted>=14.0.0', 'six>=1.10.0'] + py2_ipa,
      )

--- a/txthings/coap.py
+++ b/txthings/coap.py
@@ -266,7 +266,7 @@ media_types_rev = {v:k for k, v in media_types.items()}
 class Message(object):
     """A CoAP Message."""
 
-    def __init__(self, mtype=None, mid=None, code=EMPTY, payload='', token=''):
+    def __init__(self, mtype=None, mid=None, code=EMPTY, payload=b'', token=b''):
         self.version = 1
         self.mtype = mtype
         self.mid = mid
@@ -368,7 +368,7 @@ class Message(object):
            This method is used by client after receiving
            blockwise response from server with "more" flag set."""
         request = copy.deepcopy(self)
-        request.payload = ""
+        request.payload = b""
         request.mid = None
         if response.opt.block2.block_number == 0 and response.opt.block2.size_exponent > DEFAULT_BLOCK_SIZE_EXP:
             new_size_exponent = DEFAULT_BLOCK_SIZE_EXP

--- a/txthings/coap.py
+++ b/txthings/coap.py
@@ -3,18 +3,21 @@ Created on 08-09-2012
 
 @author: Maciej Wasilak
 '''
-import sys
-import random
-import copy
-import struct
-import collections
 from itertools import chain
+import codecs
+import collections
+import copy
+import random
+import struct
+import sys
 
 from twisted.internet import protocol, defer, reactor
 from twisted.python import log, failure
 import txthings.error as error
 
 from ipaddress import ip_address
+
+import six
 
 COAP_PORT = 5683
 """The IANA-assigned standard port for COAP services."""
@@ -303,12 +306,12 @@ class Message(object):
         """Create binary representation of message from Message object."""
         if self.mtype is None or self.mid is None:
             raise TypeError("Fatal Error: Message Type and Message ID must not be None.")
-        rawdata = chr((self.version << 6) + ((self.mtype & 0x03) << 4) + (len(self.token) & 0x0F))
+        rawdata = six.int2byte((self.version << 6) + ((self.mtype & 0x03) << 4) + (len(self.token) & 0x0F))
         rawdata += struct.pack('!BH', self.code, self.mid)
         rawdata += self.token
         rawdata += self.opt.encode()
         if len(self.payload) > 0:
-            rawdata += chr(0xFF)
+            rawdata += six.int2byte(0xFF)
             rawdata += self.payload
         return rawdata
 
@@ -434,12 +437,12 @@ class Options(object):
         for option in option_list:
             delta, extended_delta = writeExtendedFieldValue(option.number - current_opt_num)
             length, extended_length = writeExtendedFieldValue(option.length)
-            data.append(chr(((delta & 0x0F) << 4) + (length & 0x0F)))
+            data.append(six.int2byte((((int(delta) & 0x0F) << 4) + (int(length) & 0x0F))))
             data.append(extended_delta)
             data.append(extended_length)
             data.append(option.encode())
             current_opt_num = option.number
-        return (''.join(data))
+        return b"".join(data)
 
     def addOption(self, option):
         """Add option into option header."""
@@ -459,11 +462,11 @@ class Options(object):
 
     def _setUriPath(self, segments):
         """Convenience setter: Uri-Path option"""
-        if isinstance(segments, basestring): #For Python >3.1 replace with isinstance(segments,str)
+        if isinstance(segments, six.binary_type):
             raise ValueError("URI Path should be passed as a list or tuple of segments")
         self.deleteOption(number=URI_PATH)
         for segment in segments:
-            self.addOption(StringOption(number=URI_PATH, value=str(segment)))
+            self.addOption(StringOption(number=URI_PATH, value=six.binary_type(segment)))
 
     def _getUriPath(self):
         """Convenience getter: Uri-Path option"""
@@ -478,11 +481,11 @@ class Options(object):
 
     def _setUriQuery(self, segments):
         """Convenience setter: Uri-Query option"""
-        if isinstance(segments, basestring): #For Python >3.1 replace with isinstance(segments,str)
+        if isinstance(segments, six.binary_type):
             raise ValueError("URI Query should be passed as a list or tuple of segments")
         self.deleteOption(number=URI_QUERY)
         for segment in segments:
-            self.addOption(StringOption(number=URI_QUERY, value=str(segment)))
+            self.addOption(StringOption(number=URI_QUERY, value=six.binary_type(segment)))
 
     def _getUriQuery(self):
         """Convenience getter: Uri-Query option"""
@@ -597,11 +600,11 @@ class Options(object):
 
     def _setLocationPath(self, segments):
         """Convenience setter: Location-Path option"""
-        if isinstance(segments, basestring): #For Python >3.1 replace with isinstance(segments,str)
+        if isinstance(segments, six.binary_type):
             raise ValueError("Location Path should be passed as a list or tuple of segments")
         self.deleteOption(number=LOCATION_PATH)
         for segment in segments:
-            self.addOption(StringOption(number=LOCATION_PATH, value=str(segment)))
+            self.addOption(StringOption(number=LOCATION_PATH, value=six.binary_type(segment)))
 
     def _getLocationPath(self):
         """Convenience getter: Location-Path option"""
@@ -633,7 +636,7 @@ def writeExtendedFieldValue(value):
        In CoAP option delta and length can be represented by a variable
        number of bytes depending on the value."""
     if value >= 0 and value < 13:
-        return (value, '')
+        return (value, b'')
     elif value >= 13 and value < 269:
         return (13, struct.pack('!B', value - 13))
     elif value >= 269 and value < 65804:
@@ -689,13 +692,13 @@ class UintOption(object):
         self.number = number
 
     def encode(self):
-        rawdata = struct.pack("!L", self.value)  # For Python >3.1 replace with int.to_bytes()
-        return rawdata.lstrip(chr(0))
+        rawdata = struct.pack("!L", self.value)
+        return rawdata.lstrip(six.int2byte(0))
 
-    def decode(self, rawdata):  # For Python >3.1 replace with int.from_bytes()
+    def decode(self, rawdata):
         value = 0
-        for byte in rawdata:
-            value = (value * 256) + ord(byte)
+        for byte in six.iterbytes(rawdata):
+            value = (value * 256) + byte
         self.value = value
         return self
 
@@ -719,13 +722,13 @@ class BlockOption(object):
 
     def encode(self):
         as_integer = (self.value[0] << 4) + (self.value[1] * 0x08) + self.value[2]
-        rawdata = struct.pack("!L", as_integer)  # For Python >3.1 replace with int.to_bytes()
-        return rawdata.lstrip(chr(0))
+        rawdata = struct.pack("!L", as_integer)
+        return rawdata.lstrip(six.int2byte(0))
 
     def decode(self, rawdata):
         as_integer = 0
-        for byte in rawdata:
-            as_integer = (as_integer * 256) + ord(byte)
+        for byte in six.iterbytes(rawdata):
+            as_integer = (as_integer * 256) + byte
         self.value = self.BlockwiseTuple(block_number=(as_integer >> 4), more=bool(as_integer & 0x08), size_exponent=(as_integer & 0x07))
 
     def _length(self):
@@ -764,7 +767,7 @@ def isSuccessful(code):
 
 
 def uriPathAsString(segment_list):
-    return '/' + '/'.join(segment_list)
+    return b'/' + b'/'.join(segment_list)
 
 
 class Coap(protocol.DatagramProtocol):
@@ -856,7 +859,7 @@ class Coap(protocol.DatagramProtocol):
                 self.removeExchange(response)
             else:
                 return
-        log.msg("Received Response, token: %s, host: %s, port: %s" % (response.token.encode('hex'), response.remote[0], response.remote[1]))
+        log.msg("Received Response, token: %s, host: %s, port: %s" % (codecs.encode(response.token, 'hex'), response.remote[0], response.remote[1]))
         if (response.token, response.remote) in self.outgoing_requests:
             self.outgoing_requests.pop((response.token, response.remote)).handleResponse(response)
             ackIfConfirmable()
@@ -951,7 +954,7 @@ class Coap(protocol.DatagramProtocol):
         #TODO: add proper Token handling
         token = self.token
         self.token = (self.token + 1) & 0xffffffffffffffff
-        return ("%08x"%self.token).decode('hex')
+        return codecs.decode((b"%08x" % self.token), "hex")
 
     def addExchange(self, message):
         """Add an "exchange" for outgoing CON message.
@@ -1072,7 +1075,7 @@ class Requester(object):
             timeout = reactor.callLater(REQUEST_TIMEOUT, timeoutRequest, d)
             d.addBoth(gotResult)
             self.protocol.outgoing_requests[(request.token, request.remote)] = self
-            log.msg("Sending request - Token: %s, Host: %s, Port: %s" % (request.token.encode('hex'), str(request.remote[0]), request.remote[1]))
+            log.msg("Sending request - Token: %s, Host: %s, Port: %s" % (codecs.encode(request.token, 'hex'), str(request.remote[0]), request.remote[1]))
             if request.opt.observe is not None and self.cbs[0][0] is not None:
                 d.addCallback(self.registerObservation, self.cbs[0], request.opt.uri_path)
             return d
@@ -1105,6 +1108,8 @@ class Requester(object):
                 else:
                     next_block = self.app_request.extractBlock(self.app_request.opt.block1.block_number + 1, block1.size_exponent)
                 if next_block is not None:
+                    if block1.more is False:
+                        return defer.fail()
                     self.app_request.opt.block1 = next_block.opt.block1
                     block1Callback, args, kw = self.cbs[1]
                     if block1Callback is None:
@@ -1222,7 +1227,7 @@ class Responder(object):
                 try:
                     self.assembled_request.appendRequestBlock(request)
                 except (error.NotImplemented, AttributeError):
-                    self.respondWithError(request, NOT_IMPLEMENTED, "Error: Request block received out of order!")
+                    self.respondWithError(request, NOT_IMPLEMENTED, b"Error: Request block received out of order!")
                     return defer.fail(error.NotImplemented())
                     #raise error.NotImplemented
             if block1.more is True:
@@ -1257,11 +1262,11 @@ class Responder(object):
             resource = self.protocol.endpoint.getResourceFor(request)
             d = resource.render(request)
         except error.NoResource:
-            self.respondWithError(request, NOT_FOUND, "Error: Resource not found!")
+            self.respondWithError(request, NOT_FOUND, b"Error: Resource not found!")
         except error.UnallowedMethod:
-            self.respondWithError(request, METHOD_NOT_ALLOWED, "Error: Method not allowed!")
+            self.respondWithError(request, METHOD_NOT_ALLOWED, b"Error: Method not allowed!")
         except error.UnsupportedMethod:
-            self.respondWithError(request, METHOD_NOT_ALLOWED, "Error: Method not recognized!")
+            self.respondWithError(request, METHOD_NOT_ALLOWED, b"Error: Method not recognized!")
         else:
             delayed_ack = reactor.callLater(EMPTY_ACK_DELAY, self.sendEmptyAck, request)
             if resource.observable and request.code == GET and request.opt.observe is not None:
@@ -1414,7 +1419,7 @@ class Responder(object):
         #if isResponse(response.code) is False:
             #raise ValueError("Message code is not valid for a response.")
         response.token = request.token
-        log.msg("Token: %s" % ":".join("{:02x}".format(ord(c)) for c in response.token))
+        log.msg("Token: %s" % ":".join(("{:02x}".format(c) for c in six.iterbytes(response.token))))
         response.remote = request.remote
         if request.opt.block1 is not None:
             response.opt.block1 = request.opt.block1

--- a/txthings/coap.py
+++ b/txthings/coap.py
@@ -3,6 +3,7 @@ Created on 08-09-2012
 
 @author: Maciej Wasilak
 '''
+import sys
 import random
 import copy
 import struct
@@ -11,7 +12,7 @@ from itertools import chain
 
 from twisted.internet import protocol, defer, reactor
 from twisted.python import log, failure
-import error
+import txthings.error as error
 
 from ipaddress import ip_address
 
@@ -392,6 +393,13 @@ class Message(object):
             response.opt.block1 = (self.opt.block1.block_number, True, self.opt.block1.size_exponent)
         return response
 
+    def debugString(self):
+        """Generate pretty string with message contents for debugging purposes"""
+        output = []
+        output.append("v:%d " % self.version)
+        output.append("t:%s " % types[self.mtype])
+        output.append("tkl:%d " % len(self.token))
+        output.append("")
 
 class Options(object):
     """Represent CoAP Header Options."""
@@ -403,9 +411,9 @@ class Options(object):
         option_number = 0
 
         while len(rawdata) > 0:
-            if ord(rawdata[0]) == 0xFF:
+            dllen = struct.unpack('!B', rawdata[:1])[0]
+            if dllen == 0xFF:
                 return rawdata[1:]
-            dllen = ord(rawdata[0])
             delta = (dllen & 0xF0) >> 4
             length = (dllen & 0x0F)
             rawdata = rawdata[1:]
@@ -612,7 +620,7 @@ def readExtendedFieldValue(value, rawdata):
     if value >= 0 and value < 13:
         return (value, rawdata)
     elif value == 13:
-        return (ord(rawdata[0]) + 13, rawdata[1:])
+        return (struct.unpack('!B', rawdata[:1])[0] + 13, rawdata[1:])
     elif value == 14:
         return (struct.unpack('!H', rawdata[:2])[0] + 269, rawdata[2:])
     else:
@@ -773,7 +781,8 @@ class Coap(protocol.DatagramProtocol):
         self.incoming_requests = {}  # unfinished incoming requests (identified by URL path and remote)
         self.observations = {} # outgoing observations. (token, remote) -> callback
 
-    def datagramReceived(self, data, (host, port)):
+    def datagramReceived(self, data, remote):
+        host, port = remote
         log.msg("Received %r from %s:%d" % (data, host, port))
         message = Message.decode(data, (ip_address(host), port), self)
         if self.deduplicateMessage(message) is True:

--- a/txthings/resource.py
+++ b/txthings/resource.py
@@ -7,12 +7,11 @@ Implementation of the lowest-level Resource class.
 """
 
 import copy
-import warnings
 
-from zope.interface import Attribute, implements, Interface
+from zope.interface import implementer
 
-import error
-import coap
+import txthings.error as error
+import txthings.coap as coap
 from itertools import chain
 from twisted.python import log
 from twisted.python.reflect import prefixedMethodNames
@@ -29,14 +28,12 @@ def getChildForRequest(resource, request):
         resource = resource.getChildWithDefault(pathElement, request)
     return resource
 
-
+@implementer(IResource)
 class CoAPResource:
     """
     CoAP-accessible resource.
 
     """
-
-    implements(IResource)
 
     #entityType = IResource
 

--- a/txthings/test/test_coap.py
+++ b/txthings/test/test_coap.py
@@ -5,64 +5,65 @@ Created on 16-10-2012
 '''
 from twisted.trial import unittest
 from txthings import coap
+import six
 
 class TestMessage(unittest.TestCase):
-    
+
     def test_encode(self):
         msg1 = coap.Message(mtype=coap.CON, mid=0)
-        binary1 = chr(64)+chr(0)+chr(0)+chr(0)
+        binary1 = (chr(64)+chr(0)+chr(0)+chr(0)).encode()
         self.assertEqual(msg1.encode(), binary1, "wrong encode operation for empty CON message")
-        
-        msg2 = coap.Message(mtype=coap.ACK, mid=0xBC90, code=coap.CONTENT, payload="temp = 22.5 C", token='q')
-        msg2.opt.etag = "abcd"
-        binary2 = chr(97)+chr(69)+chr(188)+chr(144)+chr(113)+chr(68)+"abcd"+chr(255)+"temp = 22.5 C"
+
+        msg2 = coap.Message(mtype=coap.ACK, mid=0xBC90, code=coap.CONTENT, payload=b"temp = 22.5 C", token=b'q')
+        msg2.opt.etag = b"abcd"
+        binary2 = (six.int2byte(97)+six.int2byte(69)+six.int2byte(188)+six.int2byte(144)+six.int2byte(113)+six.int2byte(68)+b"abcd"+six.int2byte(255)+b"temp = 22.5 C")
         self.assertEqual(msg2.encode(), binary2, "wrong encode operation for ACK message with payload, and Etag option")
 
         msg3 = coap.Message()
         self.assertRaises(TypeError, msg3.encode)
 
     def test_decode(self):
-        rawdata1 = chr(64)+chr(0)+chr(0)+chr(0)
+        rawdata1 = (chr(64)+chr(0)+chr(0)+chr(0)).encode()
         self.assertEqual(coap.Message.decode(rawdata1).mtype, coap.CON, "wrong message type for decode operation")
         self.assertEqual(coap.Message.decode(rawdata1).mid, 0, "wrong message ID for decode operation")
         self.assertEqual(coap.Message.decode(rawdata1).code, coap.EMPTY, "wrong message code for decode operation")
-        self.assertEqual(coap.Message.decode(rawdata1).token, '', "wrong message token for decode operation")                                                    
-        self.assertEqual(coap.Message.decode(rawdata1).payload, '', "wrong message payload for decode operation")   
-        rawdata2 = chr(97)+chr(69)+chr(188)+chr(144)+chr(113)+chr(68)+"abcd"+chr(255)+"temp = 22.5 C"
+        self.assertEqual(coap.Message.decode(rawdata1).token, b'', "wrong message token for decode operation")
+        self.assertEqual(coap.Message.decode(rawdata1).payload, '', "wrong message payload for decode operation")
+        rawdata2 = (six.int2byte(97)+six.int2byte(69)+six.int2byte(188)+six.int2byte(144)+six.int2byte(113)+six.int2byte(68)+b"abcd"+six.int2byte(255)+b"temp = 22.5 C")
         self.assertEqual(coap.Message.decode(rawdata2).mtype, coap.ACK, "wrong message type for decode operation")
         self.assertEqual(coap.Message.decode(rawdata2).mid, 0xBC90, "wrong message ID for decode operation")
         self.assertEqual(coap.Message.decode(rawdata2).code, coap.CONTENT, "wrong message code for decode operation")
-        self.assertEqual(coap.Message.decode(rawdata2).token, 'q', "wrong message token for decode operation")                                                    
-        self.assertEqual(coap.Message.decode(rawdata2).payload, 'temp = 22.5 C', "wrong message payload for decode operation")
-        self.assertEqual(coap.Message.decode(rawdata2).opt.etags, ["abcd"], "problem with etag option decoding for decode operation")  
+        self.assertEqual(coap.Message.decode(rawdata2).token, b'q', "wrong message token for decode operation")
+        self.assertEqual(coap.Message.decode(rawdata2).payload, b'temp = 22.5 C', "wrong message payload for decode operation")
+        self.assertEqual(coap.Message.decode(rawdata2).opt.etags, [b"abcd"], "problem with etag option decoding for decode operation")
         self.assertEqual(len(coap.Message.decode(rawdata2).opt._options), 1, "wrong number of options after decode operation")
 
 class TestReadExtendedFieldValue(unittest.TestCase):
 
     def test_readExtendedFieldValue(self):
-        arguments = ((0, "aaaa"),
-                     (0, ""),
-                     (1, "aaaa"),
-                     (12,"aaaa"),
-                     (13,"aaaa"),
-                     (13,"a"),
-                     (14,"aaaa"),
-                     (14,"aa"))
-        results = ((0, "aaaa"),
-                   (0, ""), 
-                   (1, "aaaa"),
-                   (12,"aaaa"),
-                   (110,"aaa"),
-                   (110,""),
-                   (25198,"aa"),
-                   (25198,""))
+        arguments = ((0, b"aaaa"),
+                     (0, b""),
+                     (1, b"aaaa"),
+                     (12,b"aaaa"),
+                     (13,b"aaaa"),
+                     (13,b"a"),
+                     (14,b"aaaa"),
+                     (14,b"aa"))
+        results = ((0, b"aaaa"),
+                   (0, b""),
+                   (1, b"aaaa"),
+                   (12,b"aaaa"),
+                   (110,b"aaa"),
+                   (110,b""),
+                   (25198,b"aa"),
+                   (25198,b""))
 
         for argument, result in zip(arguments, results):
-            self.assertEqual(coap.readExtendedFieldValue(argument[0], argument[1]), result,'wrong result for value : '+ str(argument[0]) + ' , rawdata : ' + argument[1])
+            self.assertEqual(coap.readExtendedFieldValue(argument[0], argument[1]), result,'wrong result for value : '+ str(argument[0]) + ' , rawdata : ' + argument[1].decode())
 
 
-class TestUintOption(unittest.TestCase):     
-    
+class TestUintOption(unittest.TestCase):
+
     def test_encode(self):
         arguments = (0,
                      1,
@@ -72,26 +73,26 @@ class TestUintOption(unittest.TestCase):
                      255,
                      256,
                      1000)
-        results =   ("",
-                     chr(1),
-                     chr(2),
-                     chr(40),
-                     chr(50),
-                     chr(255),
-                     chr(1)+chr(0),
-                     chr(3)+chr(232))
+        results =   (b"",
+                     chr(1).encode(),
+                     chr(2).encode(),
+                     chr(40).encode(),
+                     chr(50).encode(),
+                     six.int2byte(255),
+                     six.int2byte(1) + six.int2byte(0),
+                     six.int2byte(3) + six.int2byte(232))
         for argument, result in zip(arguments, results):
-            self.assertEqual(coap.UintOption(0,argument).encode(), result,'wrong encode operation for option value : '+ str(argument))      
-    
+            self.assertEqual(coap.UintOption(0,argument).encode(), result,'wrong encode operation for option value : '+ str(argument))
+
     def test_decode(self):
-        arguments = ("",
-                     chr(1),
-                     chr(2),
-                     chr(40),
-                     chr(50),
-                     chr(255),
-                     chr(1)+chr(0),
-                     chr(3)+chr(232))
+        arguments = (b"",
+                     chr(1).encode(),
+                     chr(2).encode(),
+                     chr(40).encode(),
+                     chr(50).encode(),
+                     six.int2byte(255),
+                     six.int2byte(1) + six.int2byte(0),
+                     six.int2byte(3) + six.int2byte(232))
         results =   (0,
                      1,
                      2,
@@ -101,8 +102,8 @@ class TestUintOption(unittest.TestCase):
                      256,
                      1000)
         for argument, result in zip(arguments, results):
-            self.assertEqual(coap.UintOption(0).decode(argument).value, result,'wrong decode operation for rawdata : '+ str(argument))      
-    
+            self.assertEqual(coap.UintOption(0).decode(argument).value, result,'wrong decode operation for rawdata : '+ str(argument))
+
     def test_length(self):
         arguments = (0,
                      1,
@@ -119,24 +120,24 @@ class TestUintOption(unittest.TestCase):
                      1,
                      1,
                      2,
-                     2) 
+                     2)
         for argument, result in zip(arguments, results):
             self.assertEqual(coap.UintOption(0,argument)._length(), result,'wrong length for option value : '+ str(argument))
 
 
 class TestOptions(unittest.TestCase):
-                
+
     def test_setUriPath(self):
         opt1 = coap.Options()
-        opt1.uri_path = ["core"]
+        opt1.uri_path = [b"core"]
         self.assertEqual(len(opt1.getOption(coap.URI_PATH)), 1, 'wrong uri_path setter operation for single string argument')
-        self.assertEqual(opt1.getOption(coap.URI_PATH)[0].value, "core", 'wrong uri_path setter operation for single string argument')
+        self.assertEqual(opt1.getOption(coap.URI_PATH)[0].value, b"core", 'wrong uri_path setter operation for single string argument')
         opt2 = coap.Options()
-        opt2.uri_path = ("core",".well-known")
+        opt2.uri_path = (b"core",b".well-known")
         self.assertEqual(len(opt2.getOption(coap.URI_PATH)), 2, 'wrong uri_path setter operation for 2-element tuple argument')
-        self.assertEqual(opt2.getOption(coap.URI_PATH)[0].value, "core", 'wrong uri_path setter operation for 2-element tuple argument')
-        self.assertEqual(opt2.getOption(coap.URI_PATH)[1].value, ".well-known", 'wrong uri_path setter operation for 2-element tuple argument')             
+        self.assertEqual(opt2.getOption(coap.URI_PATH)[0].value, b"core", 'wrong uri_path setter operation for 2-element tuple argument')
+        self.assertEqual(opt2.getOption(coap.URI_PATH)[1].value, b".well-known", 'wrong uri_path setter operation for 2-element tuple argument')
         opt3 = coap.Options()
-        self.assertRaises(ValueError, setattr, opt3, "uri_path", "core")
-                                
-      
+        self.assertRaises(ValueError, setattr, opt3, "uri_path", b"core")
+
+

--- a/txthings/test/test_communication.py
+++ b/txthings/test/test_communication.py
@@ -61,7 +61,7 @@ class TestGetRemoteResource(unittest.TestCase):
         
     def test_exchange(self):
         request = coap.Message(code=coap.GET)
-        request.opt.uri_path = ('text',)
+        request.opt.uri_path = (b'text',)
         request.remote = (SERVER_ADDRESS, SERVER_PORT)
         d = self.client_protocol.request(request)
         d.addCallback(self.evaluateResponse)


### PR DESCRIPTION
This PR adds the missing bits for Python 3 support to the `feature-python3` branch, and rebases the whole thing onto the current master branch.

I only run the tests from `test_coap.py` as I do not have your endpoints from `test_communication.py` available. However, I have used this branch for about two weeks now to communicate with both CoAP servers and clients, both in Python 2 and Python 3, and haven't run into any difficulties so far.

Tests:

```
$ pytest2 -k coap
============================= test session starts ==============================
platform linux2 -- Python 2.7.12, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
rootdir: /tmp/tmp-6185/txThings, inifile:
collected 8 items                                                              

test_coap.py .......                                                     [100%]

============================== 1 tests deselected ==============================
==================== 7 passed, 1 deselected in 0.09 seconds ====================
$ pytest3 -k coap
============================= test session starts ==============================
platform linux -- Python 3.5.2, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
rootdir: /tmp/tmp-6185/txThings, inifile:
collected 8 items                                                              

test_coap.py .......                                                     [100%]

============================== 1 tests deselected ==============================
==================== 7 passed, 1 deselected in 0.13 seconds ====================
$ 
```

(I developed this change at Amazon; kind thanks to my employer for allowing me to contribute it back upstream :-))